### PR TITLE
server.properties: do existence check on ‘kafka_listen_address’

### DIFF
--- a/templates/server.properties.j2
+++ b/templates/server.properties.j2
@@ -11,7 +11,7 @@ port=9092
 # Hostname the broker will bind to and advertise to producers and consumers.
 # If not set, the server will bind to all interfaces and advertise the value returned from
 # from java.net.InetAddress.getCanonicalHostName().
-{% if kafka_listen_address %}
+{% if kafka_listen_address is defined %}
 host.name={{kafka_listen_address}}
 {% else %}
 #host.name=localhost
@@ -19,7 +19,7 @@ host.name={{kafka_listen_address}}
 
 # The number of threads handling network requests
 num.network.threads=2
- 
+
 # The number of threads doing disk I/O
 num.io.threads=2
 
@@ -49,7 +49,7 @@ num.partitions=2
 # There are a few important trade-offs here:
 #    1. Durability: Unflushed data may be lost if you are not using replication.
 #    2. Latency: Very large flush intervals may lead to latency spikes when the flush does occur as there will be a lot of data to flush.
-#    3. Throughput: The flush is generally the most expensive operation, and a small flush interval may lead to exceessive seeks. 
+#    3. Throughput: The flush is generally the most expensive operation, and a small flush interval may lead to exceessive seeks.
 # The settings below allow one to configure the flush policy to flush data after a period of time or
 # every N messages (or both). This can be done globally and overridden on a per-topic basis.
 
@@ -79,7 +79,7 @@ log.retention.hours=168
 # The maximum size of a log segment file. When this size is reached a new log segment will be created.
 log.segment.bytes=536870912
 
-# The interval at which log segments are checked to see if they can be deleted according 
+# The interval at which log segments are checked to see if they can be deleted according
 # to the retention policies
 log.cleanup.interval.mins=1
 


### PR DESCRIPTION
was getting this error prior to fix: 

```
TASK: [kafka | create server.properties] ************************************** 
<192.168.33.19> ESTABLISH CONNECTION FOR USER: vagrant
<192.168.33.19> EXEC ssh -C -tt -vvv -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s -o ControlPath=/Users/tom/.ansible/cp/ansible-ssh-%h-%p-%r -o StrictHostKeyChecking=no -o IdentityFile="/Users/tom/.vagrant.d/insecure_private_key" -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=vagrant -o ConnectTimeout=10 192.168.33.19 /bin/sh -c 'mkdir -p $HOME/.ansible/tmp/ansible-tmp-1413498244.14-110580405837030 && chmod a+rx $HOME/.ansible/tmp/ansible-tmp-1413498244.14-110580405837030 && echo $HOME/.ansible/tmp/ansible-tmp-1413498244.14-110580405837030'
fatal: [kafka1] => {'msg': "AnsibleUndefinedVariable: One or more undefined variables: 'kafka_listen_address' is undefined", 'failed': True}
fatal: [kafka1] => {'msg': "AnsibleUndefinedVariable: One or more undefined variables: 'kafka_listen_address' is undefined", 'failed': True}

FATAL: all hosts have already failed -- aborting

PLAY RECAP ******************************************************************** 
           to retry, use: --limit @/Users/tom/servers.retry

kafka1                     : ok=47   changed=37   unreachable=1    failed=0   

Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```
