### PR TITLE
kafka.conf looks for zookeeper init.d script now.

### DIFF
--- a/files/kafka.conf
+++ b/files/kafka.conf
@@ -12,7 +12,7 @@ setgid kafka
 
 # If zookeeper is running on this box also give it time to start up properly
 pre-start script
-    if [ -e /etc/init/zookeeper.conf ]; then
+    if [ -e /etc/init.d/zookeeper ]; then
         sleep 5
     fi
 end script


### PR DESCRIPTION
kafka.conf was pointing at an old zookeeper.conf file to decide to wait for
zookeeper to start.  Now we're pointing at the proper zookeeper init script.
