### PR TITLE
adding apt cache update and upgrade

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: update APT package cache
+  sudo: yes
+  apt: update_cache=yes
+
+- name: upgrade all safe packages
+  sudo: yes
+  apt: upgrade=safe
+  
 - name: Install OpenJDK
   apt: name=openjdk-7-jre-headless state=present
   when: not skip_install


### PR DESCRIPTION
Before running the apt commands to install openjdk, etc, we should update the apt cache and upgrade - this ensures that we won't have any problems with stale apt caches.  When using this project to lay down kafka on a newly deployed ec2 node, I was receiving errors about unreachable sources for ubuntu packages.  apt update and cache update resolves this issue.