### PR TITLE
Fix mode arguments to be octal not decimal numbers

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -26,13 +26,13 @@
   when: init.stdout != 'systemd'
 
 - name: create upstart config
-  template: dest={{kafka_upstart_conf}} owner=root group=root mode=644 src=kafka.conf.j2
+  template: dest={{kafka_upstart_conf}} owner=root group=root mode=0644 src=kafka.conf.j2
   notify:
     - restart kafka
   when: not use_systemd
 
 - name: create systemd config
-  template: dest={{kafka_systemd_service}} owner=root group=root mode=644 src=kafka.service.j2
+  template: dest={{kafka_systemd_service}} owner=root group=root mode=0644 src=kafka.service.j2
   notify:
     - restart kafka
   when: use_systemd
@@ -41,26 +41,26 @@
   when: use_systemd
 
 - name: Create data_dir
-  file: path={{kafka_data_dir}} state=directory owner={{kafka_user}} group={{kafka_group}} mode=755
+  file: path={{kafka_data_dir}} state=directory owner={{kafka_user}} group={{kafka_group}} mode=0755
 
 - name: Remove lost+found in the datadir
   file: path="{{kafka_data_dir}}/lost+found" state=absent
 
 - name: Create log_dir
-  file: path={{kafka_log_dir}} state=directory owner={{kafka_user}} group={{kafka_group}} mode=755
+  file: path={{kafka_log_dir}} state=directory owner={{kafka_user}} group={{kafka_group}} mode=0755
 
 - name: link conf_dir to /opt/kafka/config
   file: path={{kafka_conf_dir}} state=link src=/opt/kafka/config
 
 # Setup log4j.properties
 - name: create log4j.properties
-  template: dest="{{kafka_conf_dir}}/log4j.properties" owner={{kafka_user}} group={{kafka_group}} mode=644 src=log4j.properties.j2
+  template: dest="{{kafka_conf_dir}}/log4j.properties" owner={{kafka_user}} group={{kafka_group}} mode=0644 src=log4j.properties.j2
   notify:
     - restart kafka
 
 # Setup server.properties
 - name: create server.properties
-  template: dest="{{kafka_conf_dir}}/server.properties" owner={{kafka_user}} group={{kafka_group}} mode=640 src=server.properties.j2
+  template: dest="{{kafka_conf_dir}}/server.properties" owner={{kafka_user}} group={{kafka_group}} mode=0640 src=server.properties.j2
   notify:
     - restart kafka
 


### PR DESCRIPTION
From the ansible documentation:
"For those used to /usr/bin/chmod remember that modes are
actually octal numbers (like 0644). Leaving off the leading
zero will likely have unexpected results."
